### PR TITLE
Deprecation fix

### DIFF
--- a/lib/dj_remixes/worker.rb
+++ b/lib/dj_remixes/worker.rb
@@ -28,7 +28,7 @@ module DJ
     end
     
     def enqueue!(priority = self.priority, run_at = self.run_at)
-      job = DJ.enqueue(self, priority, run_at)
+      job = DJ.enqueue(:payload_object => self, :priority => priority, :run_at => run_at)
       job.worker_class_name = self.worker_class_name
       job.save
       return job


### PR DESCRIPTION
Hey - I modified the call to DJ.enqueue in worker.rb to get rid of the deprecation warning that was occurring with DJ 2.1.1. 

I changed it to only pass in a hash so that it also still works with previous versions of DJ.
