### PR TITLE
Updated readme & fixed Object#id deprecation message

### DIFF
--- a/README
+++ b/README
@@ -19,14 +19,29 @@ These are a few of the extras for DJ that are included here.
 
 In your <code>Gemfile</code> add the following:
 
-  gem 'delayed_job', :git => 'git://github.com/collectiveidea/delayed_job.git'
-  gem 'dj_remixes', '>= 0.2.0'
+  gem "delayed_job", "2.1.4"
+  gem "dj_remixes"
 
 Then install the gems:
 
   $ bundle install
 
-*NOTE*: At this time DJ Remixes requires the latest and greatest in the delayed_job master branch. When DJ 2.1.0 is officially released this requirement should go away.
+
+Create a migration to add the required dj_remixes fields to the delayed_job table:
+
+  class AddDjRemixesColumns < ActiveRecord::Migration
+    def self.up
+      add_column :delayed_jobs, :worker_class_name,   :string
+      add_column :delayed_jobs, :started_at,          :datetime
+      add_column :delayed_jobs, :finished_at,         :datetime
+    end
+
+    def self.down
+      remove_column :delayed_jobs, :worker_class_name
+      remove_column :delayed_jobs, :started_at
+      remove_column :delayed_jobs, :finished_at
+    end
+  end
 
 ==Using
 

--- a/README.textile
+++ b/README.textile
@@ -20,7 +20,7 @@ h2. Installation
 In your <code>Gemfile</code> add the following:
 
 <pre><code>
-  gem "delayed_job", "2.1.1"
+  gem "delayed_job", "2.1.4"
   gem "dj_remixes"
 </code></pre>
 
@@ -30,7 +30,24 @@ Then install the gems:
   $ bundle install
 </code></pre>
 
-*NOTE*: At this time DJ Remixes requires the latest and greatest in the delayed_job master branch. When DJ 2.1.0 is officially released this requirement should go away.
+Create a migration to add the required dj_remixes fields to the delayed_job table:
+
+<pre><code>
+  class AddDjRemixesColumns < ActiveRecord::Migration
+    def self.up
+      add_column :delayed_jobs, :worker_class_name,   :string
+      add_column :delayed_jobs, :started_at,          :datetime
+      add_column :delayed_jobs, :finished_at,         :datetime
+    end
+
+    def self.down
+      remove_column :delayed_jobs, :worker_class_name
+      remove_column :delayed_jobs, :started_at
+      remove_column :delayed_jobs, :finished_at
+    end
+  end
+</code></pre>
+
 
 h2. Using
 
@@ -125,4 +142,5 @@ h2. Contributors
 
 * Mark Bates
 * Stuart Garner
-* Lars Pind
+* Brent Kirby
+* Lars Pindrake 

--- a/lib/dj_remixes/worker.rb
+++ b/lib/dj_remixes/worker.rb
@@ -20,8 +20,8 @@ module DJ
     end
     
     def worker_class_name
-      if self.id
-        @worker_class_name ||= File.join(self.class.to_s.underscore, self.id.to_s)
+      if self[:id]
+        @worker_class_name ||= File.join(self.class.to_s.underscore, self[:id].to_s)
       else
         @worker_class_name ||= self.class.to_s.underscore
       end

--- a/spec/dj_remixes/attributes_spec.rb
+++ b/spec/dj_remixes/attributes_spec.rb
@@ -5,9 +5,8 @@ describe DJ::Worker do
   describe 'attributes' do
     
     it 'should work its method_missing magic on attributes' do
-      job = SimpleWorker.new(:user => 1, 'email' => 'foo@example.com', :id => 99)
-      job.attributes.should == {'user' => 1, 'email' => 'foo@example.com', 'id' => 99}
-      job.id.should == 99
+      job = SimpleWorker.new(:user => 1, 'email' => 'foo@example.com')
+      job.attributes.should == {'user' => 1, 'email' => 'foo@example.com'}
       job.user.should == 1
       job.email.should == 'foo@example.com'
       job.user = 2


### PR DESCRIPTION
Hiya Mark,

Bumped my head on this so thought I'd update the readme to include the required migration details.

Also I was getting an Object#id deprecation message  (EDIT: when using SomeWorker.enqueue) so I just changed the code to use the attribute version self[:id] instead.  Seemed to fix errors I was having just running the specs initially too - so perhaps it would be good for you to double check?

Also feel free to amend as necessary however I'm not sure that testing the id in the attributes spec was relevant?  I removed as it was failing, but I'd kind of expected it too as the object new i.e. it wasn't saved?

Hope it's helpful

Cheers
Luke
